### PR TITLE
Change the base mongo structure to keep a reference to the session instead of a collection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - go get -u github.com/Microkubes/microservice-tools
   - go get -u github.com/guregu/dynamo
   - go get -u github.com/satori/go.uuid
-  - go get -u github.com/goadesign/goa
   - go get -u github.com/aws/aws-sdk-go/aws
   - go get -u gopkg.in/mgo.v2
 


### PR DESCRIPTION
It is recommended to keep a Session object instead of a Collection object, because of the ability to reconnect a session in case of a timeout or if the mongo service restarts.